### PR TITLE
[github] feat: setup dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[actions] chore'
+    labels:
+      - github-actions
+    target-branch: parent
+
+  - package-ecosystem: pub
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[deps] chore'
+    labels:
+      - dependency
+    target-branch: parent
+    versioning-strategy: widen


### PR DESCRIPTION
Configures GitHub to automatically check and update outdated dependencies to the latest version periodically.

Learn more about [Dependabot][1].

[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

